### PR TITLE
Disable hardware rendering to decrease ram usage from GPU related DLLs

### DIFF
--- a/Wauncher/Program.cs
+++ b/Wauncher/Program.cs
@@ -84,6 +84,10 @@ namespace Wauncher
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .WithInterFont()
+                .With(new Win32PlatformOptions
+                {
+                    RenderingMode = new[] { Win32RenderingMode.Software }
+                })
                 .LogToTrace();
     }
 }


### PR DESCRIPTION
NVIDIA dlls are at least 50% of the ram usage, when the app is idle. I don't know how much the AMD or Intel ones take up.